### PR TITLE
Update ROCm-DS to AMD Data Science

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # ROCm-DS 26.03 Release notes
 
-AMD is pleased to announce the ROCm Data Science Toolkit (ROCm-DS) 26.03 release with major component upgrades, broader hardware enablement, and new distributed computing capabilities for AMD GPU environments. ROCm-DS is an open-source data science toolkit designed to improve the performance of data preparation, analytics, machine learning, and vector search workloads on AMD GPUs. 
+AMD is pleased to announce the AMD Data Science Toolkit 26.03 release with major component upgrades, broader hardware enablement, and new distributed computing capabilities for AMD GPU environments. AMD Data Science is an open-source data science toolkit designed to improve the performance of data preparation, analytics, machine learning, and vector search workloads on AMD GPUs. 
 
 With the 26.03 release, ROCm-DS continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.3. 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 AMD is pleased to announce the AMD Data Science Toolkit 26.03 release with major component upgrades, broader hardware enablement, and new distributed computing capabilities for AMD GPU environments. AMD Data Science is an open-source data science toolkit designed to improve the performance of data preparation, analytics, machine learning, and vector search workloads on AMD GPUs. 
 
-With the 26.03 release, ROCm-DS continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.3. 
+With the 26.03 release, AMD Data Science continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.3. 
 
 ```{note}
 hipGRAPH remains early access (EA) in ROCm-DS 26.03. 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ With the 26.03 release, AMD Data Science continues to strengthen its software st
 hipGRAPH remains early access (EA) in AMD Data Science 26.03. 
 ```
 
-- [ROCm-DS Release highlights](#rocm-ds-release-highlights)
+- [AMD Data Science Release highlights](#amd-data-science-release-highlights)
 - [System requirements](#system-requirements)
 - [ROCm-DS components](#rocm-ds-components)
 - [Detailed component Changelogs](#detailed-component-changelogs)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ AMD is pleased to announce the AMD Data Science Toolkit 26.03 release with major
 With the 26.03 release, AMD Data Science continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.3. 
 
 ```{note}
-hipGRAPH remains early access (EA) in ROCm-DS 26.03. 
+hipGRAPH remains early access (EA) in AMD Data Science 26.03. 
 ```
 
 - [ROCm-DS Release highlights](#rocm-ds-release-highlights)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,7 @@ The 26.03 release includes the following major updates and highlights:
 * Python 3.13 support added in selected components. 
 * Continued support for Python and C++ APIs, helping developers integrate ROCm-DS into analytics, AI, and GPU-accelerated data science workflows. 
 
-This release advances ROCm-DS toward a more complete platform for distributed, multi-GPU, and large-scale data science workloads on AMD GPUs. 
+This release advances AMD Data Science toward a more complete platform for distributed, multi-GPU, and large-scale data science workloads on AMD GPUs. 
 
 ## System requirements
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ hipGRAPH remains early access (EA) in AMD Data Science 26.03.
 - [AMD Data Science components](#amd-data-science-components)
 - [Detailed component Changelogs](#detailed-component-changelogs)
 
-## ROCm-DS release highlights
+## AMD Data Science release highlights
 
 The 26.03 release includes the following major updates and highlights: 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 AMD is pleased to announce the ROCm Data Science Toolkit (ROCm-DS) 26.03 release with major component upgrades, broader hardware enablement, and new distributed computing capabilities for AMD GPU environments. ROCm-DS is an open-source data science toolkit designed to improve the performance of data preparation, analytics, machine learning, and vector search workloads on AMD GPUs. 
 
-With the 26.03 release, ROCm-DS continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.1. 
+With the 26.03 release, ROCm-DS continues to strengthen its software stack while improving portability for users bringing existing GPU data science workflows to AMD hardware. The 26.03 release introduces dask-hip and hip-ucxx as new components, adding foundational support for distributed and multi-GPU workflows on ROCm. In addition, core libraries, including hipDF, hipMM, hipRAFT, and hipVS, have been updated to incorporate newer upstream functionality and support for ROCm 7.2.3. 
 
 ```{note}
 hipGRAPH remains early access (EA) in ROCm-DS 26.03. 
@@ -27,7 +27,7 @@ The 26.03 release includes the following major updates and highlights:
 * Major hipMM upgrade to 4.0.0, introducing a precompiled shared library model (`librmm.so`), improved logging integration, enhanced diagnostics, and updated Python packaging. 
 * hipRAFT 1.0.0 and hipVS 1.0.0 updated with new primitives, performance improvements, API changes, and expanded multi-GPU capabilities. 
 * Expanded hardware support, including support for the gfx950 GPU architecture across major libraries, with additional experimental gfx11xx/gfx12xx RDNA support in hipDF. 
-* ROCm 7.2.1 support across updated components. 
+* ROCm 7.2.3 support across updated components. 
 * Python 3.13 support added in selected components. 
 * Continued support for Python and C++ APIs, helping developers integrate ROCm-DS into analytics, AI, and GPU-accelerated data science workflows. 
 
@@ -35,7 +35,7 @@ This release advances ROCm-DS toward a more complete platform for distributed, m
 
 ## System requirements
 
-For the 26.03 release, the ROCm-DS components support the ROCm 7.2.1 and ROCm 7.2.0 releases. Refer to the {doc}`Compatibility matrix <compatibility-matrix>` to verify supported AMD Instinct GPUs, operating systems, and ROCm versions.
+For the 26.03 release, the ROCm-DS components support the ROCm 7.2.3 release. Refer to the {doc}`Compatibility matrix <compatibility-matrix>` to verify supported AMD Instinct GPUs, operating systems, and ROCm versions.
 
 ## ROCm-DS components
 
@@ -57,39 +57,39 @@ changes. Click {fab}`github` to go to the component's source code on GitHub.
         </colgroup>
         <tbody class="rocm-ds-components">
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hipdf-internal/en/docs-rocmds-26.03/">hipDF</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hipdf/en/docs-26.03/">hipDF</a></td>
                 <td>2.0.0&nbsp;&Rightarrow;&nbsp;<a href="#hipdf-3-0-0">3.0.0</a></td>
-                <td><a href="https://github.com/ROCm-DS/hipDF"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hipDF"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hipMM-internal/en/docs-rocmds-26.03/">hipMM</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hipMM/en/docs-26.03/">hipMM</a></td>
                 <td>3.0.0&nbsp;&Rightarrow;&nbsp;<a href="#hipmm-4-0-0">4.0.0</a></td>
-                <td><a href="https://github.com/ROCm-DS/hipMM"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hipMM"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hipGRAPH/en/docs-25.10/">hipGRAPH</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hipGRAPH/en/docs-26.03/">hipGRAPH</a></td>
                 <td>1.0.0b1</td>
-                <td><a href="https://github.com/ROCm-DS/hipGRAPH"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hipGRAPH"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hipRAFT-internal/en/amd-integration/">hipRAFT</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hipRAFT/en/docs-26.03/">hipRAFT</a></td>
                 <td>0.1.0&nbsp;&Rightarrow;&nbsp;<a href="#hipraft-1-0-0">1.0.0</a></td>
-                <td><a href="https://github.com/ROCm-DS/hipRaft"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hipRaft"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hipvs-internal/en/amd-integration/">hipVS</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hipvs/en/docs-26.03/">hipVS</a></td>
                 <td>0.1.0&nbsp;&Rightarrow;&nbsp;<a href="#hipvs-1-0-0">1.0.0</a></td>
-                <td><a href="https://github.com/ROCm-DS/hipVS"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hipVS"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/dask-hip-internal/en/dev-suphilip-add_amd_documentation/">dask-hip</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/dask-hip/en/docs-26.03/">dask-hip</a></td>
                 <td><a href="#dask-hip-1-0-0">1.0.0</a></td>
-                <td><a href="https://github.com/AMD-AIOSS/dask-hip"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/dask-hip"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>
-                <td><a href="https://rocm.docs.amd.com/projects/hip-ucxx-internal/en/dev-suphilip-add-amd-docs/">hip-ucxx</a></td>
+                <td><a href="https://rocm.docs.amd.com/projects/hip-ucxx-internal/en/docs-26.03/">hip-ucxx</a></td>
                 <td><a href="#hip-ucxx-0-1-0">0.1.0</a></td>
-                <td><a href="https://github.com/AMD-AIOSS/hip-ucxx"><i class="fab fa-github fa-lg"></i></a></td>
+                <td><a href="https://github.com/AMD-Ecosystem/hip-ucxx"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
         </tbody>
     </table>
@@ -104,7 +104,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added 
 
 * API alignment with upstream 25.10 functionality 
-* Support for ROCm 7.2.1 
+* Support for ROCm 7.2.3 
 * New `pylibhipdf` wrapper module with Python bindings compatible with upstream `pylibcudf` 
 * Support for the gfx950 GPU architecture 
 * Experimental support for gfx11xx and gfx12xx RDNA architectures: 
@@ -126,7 +126,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added 
 
 * Updated to newer upstream 25.10 functionality 
-* Support for ROCm 7.2.1 
+* Support for ROCm 7.2.3 
 * Support for the gfx950 GPU architecture 
 * Transition from a header-only library to a shared library model, with core implementations now delivered in librmm.so 
 * Improved downstream build times through precompiled library delivery 
@@ -146,7 +146,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added
 
 * Updated to newer upstream 25.10 functionality 
-* ROCm 7.2.1 support 
+* ROCm 7.2.3 support 
 * Support for gfx950 
 * Added RAFT_CUDA_TRY error-checking support for HIP runtime API calls 
 * Ported NN-Descent graph construction kernel with wavefront-size-64 compatibility 
@@ -172,7 +172,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added
 
 * Updated to newer upstream 25.10 functionality 
-* ROCm 7.2.1 support 
+* ROCm 7.2.3 support 
 * Support for gfx950 
 * Enabled multi-GPU algorithms and RCCL configurations 
 * New Composable Kernel (CK) pairwise distance support for: 
@@ -203,7 +203,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added 
 
 * Initial release of dask-hip 
-* ROCm 7.2.1 support 
+* ROCm 7.2.3 support 
 * Based on upstream 25.10 functionality 
 * Ships as the amd-dask-hip Python package on AMD PyPI 
 * Introduces a `pynvml-to-amdsmi` translation layer so existing dask-cuda logic can operate on AMD GPUs with minimal changes 
@@ -225,7 +225,7 @@ The following sections describe key changes to ROCm-DS components.
 #### Added 
 
 * hip-ucxx is introduced in ROCm-DS 26.03 as a new communication component for distributed GPU workflows on AMD platforms. 
-* ROCm 7.2.1 support 
+* ROCm 7.2.3 support 
 
 ```{note}
 UCXX-based multi-node communication is early access (EA) in ROCm-DS 26.03.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,7 +35,7 @@ This release advances AMD Data Science toward a more complete platform for distr
 
 ## System requirements
 
-For the 26.03 release, the ROCm-DS components support the ROCm 7.2.3 release. Refer to the {doc}`Compatibility matrix <compatibility-matrix>` to verify supported AMD Instinct GPUs, operating systems, and ROCm versions.
+For the 26.03 release, the AMD Data Science components support the ROCm 7.2.3 release. Refer to the {doc}`Compatibility matrix <compatibility-matrix>` to verify supported AMD Instinct GPUs, operating systems, and ROCm versions.
 
 ## ROCm-DS components
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,7 @@ This release advances AMD Data Science toward a more complete platform for distr
 
 For the 26.03 release, the AMD Data Science components support the ROCm 7.2.3 release. Refer to the {doc}`Compatibility matrix <compatibility-matrix>` to verify supported AMD Instinct GPUs, operating systems, and ROCm versions.
 
-## ROCm-DS components
+## AMD Data Science components
 
 The following table lists ROCm-DS components versions for the 26.03 release, including any version
 changes. Click {fab}`github` to go to the component's source code on GitHub.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ hipGRAPH remains early access (EA) in AMD Data Science 26.03.
 
 - [AMD Data Science Release highlights](#amd-data-science-release-highlights)
 - [System requirements](#system-requirements)
-- [ROCm-DS components](#rocm-ds-components)
+- [AMD Data Science components](#amd-data-science-components)
 - [Detailed component Changelogs](#detailed-component-changelogs)
 
 ## ROCm-DS release highlights

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,18 +12,18 @@ html_context = {
 }
 if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True
-project = "ROCm for Data Science"
+project = "AMD Data Science"
 
 version = "26.03"
 release = version
-html_title = "ROCm-DS 26.03 documentation"
+html_title = "AMD Data Science 26.03 documentation"
 author = "Advanced Micro Devices, Inc."
 copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved."
 setting_all_article_info = True
 all_article_info_os = ["linux"]
 all_article_info_author = ""
 
-#left_nav_title = f"ROCm-DS {version} documentation"
+#left_nav_title = f"AMD Data Science {version} documentation"
 
 # Required settings
 html_theme = "rocm_docs_theme"

--- a/docs/contribute/contributing.rst
+++ b/docs/contribute/contributing.rst
@@ -1,27 +1,27 @@
 .. meta::
-    :description: ROCm-DS release compatibility
+    :description: contributing to AMD Data Science
     :keywords: Data-analytics, RAPIDS, cuDF, cuGraph, RMM, hipDF, hipGRAPH, hipMM, Pandas, NetworkX, High-Performance Computing, GPU Acceleration, GPU Computing, Parallel Computing, Scalable Data Science, Python
 
 .. _contributing-to-rocm-ds:
 
-*************************
-Contributing to ROCm-DS
-*************************
+*********************************
+Contributing to AMD Data Science
+*********************************
 
-AMD appreciates and values your interest in contributing to the ROCm Data Sciences (ROCm-DS) stack. This collection of libraries — hipDF, hipGRAPH,
+AMD appreciates and values your interest in contributing to the AMD Data Sciences stack. This collection of libraries — hipDF, hipGRAPH,
 hipMM, hipRAFT, hipVS, dask-hip, and hip-ucxx — is a fork of the RAPIDS® open-source project from NVIDIA and brings high-performance, GPU-accelerated data science,
 graph analytics, mathematical computation, and vector search to the ROCm ecosystem. 
  
 You can contribute in several ways: reporting bugs or requesting new features, improving documentation, performance optimizations,
-porting functionality from equivalent CUDA-based libraries, writing or improving tests.  If you want to contribute to our ROCm-DS
+porting functionality from equivalent CUDA-based libraries, writing or improving tests.  If you want to contribute to our AMD Data Science
 repositories, review the guidance below to help ensure your contributions are accepted. 
 
 Development workflow
 ====================
 
-The ROCm-DS project uses GitHub to host the code, collaborate within the community, and manage version control. The project relies on pull requests
+The AMD Data Science project uses GitHub to host the code, collaborate within the community, and manage version control. The project relies on pull requests
 for all changes within the repositories, ensuring that contributions are reviewed and discussed before being merged into the main codebase. This
-helps maintain code quality and consistency. The ROCm-DS project uses GitHub issues to track bugs, feature requests, and other-project related tasks,
+helps maintain code quality and consistency. The AMD Data Science project uses GitHub issues to track bugs, feature requests, and other-project related tasks,
 providing a transparent and organized way to monitor progress and prioritize work. 
 
 Issue tracking
@@ -99,6 +99,6 @@ Pull Request Guidelines
 Thank you for contributing
 ==========================
 
-AMD and the ROCm-DS community appreciate your time, effort, and expertise. Every contribution, whether big or small, plays a vital role in making the project
+AMD and the Data Science community appreciate your time, effort, and expertise. Every contribution, whether big or small, plays a vital role in making the project
 better and more impactful to the entire community. Your involvement helps drive innovation, enhance the quality of the software, and ensures
-the continued success of ROCm-DS. We look forward to collaborating with you and are excited to see the positive changes you'll bring to the project!
+the continued success of AMD Data Science. We look forward to collaborating with you and are excited to see the positive changes you'll bring to the project!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,33 +1,33 @@
 .. meta::
-  :description: Learn about the features and capabilities of ROCm for Data Science (ROCm-DS)
+  :description: Learn about the features and capabilities of ROCm for AMD Data Science
   :keywords: Data-analytics, RAPIDS, cuDF, cuGraph, RMM, hipDF, hipGraph, hipRAFT, hipMM, hipVS, Pandas, NetworkX, High-Performance Computing, GPU Acceleration, GPU Computing, Parallel Computing, Scalable Data Science, Python
 
 .. rocmds-index:
 
 ********************************************************************
-AMD ROCm Data Science documentation
+AMD Data Science documentation
 ********************************************************************
 
-The AMD ROCm™ Data Science toolkit (ROCm-DS) is an open-source collection of GPU-accelerated libraries designed to empower data scientists,
+The AMD Data Science toolkit is an open-source collection of GPU-accelerated libraries designed to empower data scientists,
 engineers, and researchers to build high-performance data science applications and machine learning workflows on the ROCm platform.
-Built upon the core ROCm foundation, ROCm-DS provides a unified, efficient, and scalable environment for end-to-end data science acceleration.
+Built upon the core ROCm foundation, AMD Data Science provides a unified, efficient, and scalable environment for end-to-end data science acceleration.
 
-ROCm-DS is a fork of the RAPIDS® open-source project from NVIDIA, extended and optimized for AMD GPUs. It enables users to accelerate
-both new and existing data science workloads, executing intensive applications with larger datasets at exceptional speed. With ROCm-DS,
+AMD Data Science is a fork of the RAPIDS® open-source project from NVIDIA, extended and optimized for AMD GPUs. It enables users to accelerate
+both new and existing data science workloads, executing intensive applications with larger datasets at exceptional speed. With the AMD Data Science toolkit,
 you can build pre- and post-processing applications for AI models, create big data processing workloads, or accelerate existing data
 science pipelines with minimal effort.
 
-ROCm-DS delivers a cohesive set of libraries that target every stage of the data science lifecycle, from data ingestion and transformation
+AMD Data Science delivers a cohesive set of libraries that target every stage of the data science lifecycle, from data ingestion and transformation
 to graph analytics, mathematical computation, and vector search. Each component is optimized for GPU performance while maintaining user-friendly
 interfaces compatible with existing data science frameworks and APIs.
 
-The ROCm-DS toolkit includes the following components:
+The AMD Data Science toolkit includes the following components:
 
 * **hipDF** – A GPU-accelerated DataFrame library offering fast and scalable tabular data manipulation, aggregation, and transformation. hipDF enables high-performance preprocessing, feature engineering, and ETL workflows essential for modern data pipelines. It also supports the acceleration of many existing Pandas workflows with little to no code changes.
 
-* **hipGRAPH** – Leverages GPU acceleration to process and analyze complex graph structures and networks with speed and precision. hipGRAPH supports diverse graph algorithms—such as centrality, traversal, similarity, sampling, and labeling—and integrates seamlessly with hipDF DataFrames across the ROCm-DS ecosystem.
+* **hipGRAPH** – Leverages GPU acceleration to process and analyze complex graph structures and networks with speed and precision. hipGRAPH supports diverse graph algorithms—such as centrality, traversal, similarity, sampling, and labeling—and integrates seamlessly with hipDF DataFrames across the AMD Data Science ecosystem.
 
-* **hipMM** – The HIP Memory Manager library provides advanced GPU memory management utilities such as efficient allocation, pooling, and data movement to support the various libraries that form part of ROCm-DS. 
+* **hipMM** – The HIP Memory Manager library provides advanced GPU memory management utilities such as efficient allocation, pooling, and data movement to support the various libraries that form part of the AMD Data Science toolkit. 
 
 * **hipRAFT** – Provides a foundational layer of reusable GPU-accelerated primitives for data science and machine learning, including clustering, dimensionality reduction, and statistical operations. hipRAFT serves as the computational backbone for higher-level data science and AI applications.
 
@@ -41,9 +41,9 @@ The ROCm-DS toolkit includes the following components:
 
   The hipGRAPH libraries are in an *early access* state. Running production workloads with these libraries is *not* recommended. 
 
-The ROCm-DS organization is open and hosted at `https://github.com/ROCm-DS/ <https://github.com/ROCm-DS/>`_.
+The AMD Data Science organization is open and hosted at `https://github.com/AMD-Ecosystem/DataScience <https://github.com/AMD-Ecosystem/DataScience>`_.
 
-ROCm-DS documentation is organized into the following categories:
+AMD Data Science documentation is organized into the following categories:
 
 .. grid:: 2
   :gutter: 3
@@ -65,5 +65,5 @@ ROCm-DS documentation is organized into the following categories:
   .. grid-item-card:: Related Content
 
     * `Instinct docs <https://instinct.docs.amd.com/latest/>`__
-    * `ROCm-DS blogs <https://instinct.docs.amd.com/latest/data-science/ROCmDS-Blogs.html>`__
+    * `AMD Data Science blogs <https://instinct.docs.amd.com/latest/data-science/ROCmDS-Blogs.html>`__
     * :ref:`contributing-to-rocm-ds`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ The AMD Data Science toolkit includes the following components:
 
   The hipGRAPH libraries are in an *early access* state. Running production workloads with these libraries is *not* recommended. 
 
-The AMD Data Science organization is open and hosted at `https://github.com/AMD-Ecosystem/<https://github.com/AMD-Ecosystem/>`_.
+The AMD Data Science organization is open and hosted at `https://github.com/AMD-Ecosystem/DataScience <https://github.com/AMD-Ecosystem/ROCm-DS>`_.
 
 AMD Data Science documentation is organized into the following categories:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ The AMD Data Science toolkit includes the following components:
 
   The hipGRAPH libraries are in an *early access* state. Running production workloads with these libraries is *not* recommended. 
 
-The AMD Data Science organization is open and hosted at `https://github.com/AMD-Ecosystem/DataScience <https://github.com/AMD-Ecosystem/DataScience>`_.
+The AMD Data Science organization is open and hosted at `https://github.com/AMD-Ecosystem/<https://github.com/AMD-Ecosystem/>`_.
 
 AMD Data Science documentation is organized into the following categories:
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -1,19 +1,19 @@
 .. meta::
-    :description: ROCm-DS release compatibility
+    :description: AMD Data Science installation
     :keywords: Data-analytics, RAPIDS, cuDF, cuGraph, RMM, hipDF, hipGraph, hipMM, Pandas, NetworkX, High-Performance Computing, GPU Acceleration, GPU Computing, Parallel Computing, Scalable Data Science, Python
 
 .. _linux-install:
 
 **************************************************************************************
-Installing ROCm-DS
+Installing AMD Data Science
 **************************************************************************************
 
-This topic provides brief guidance and recommendations on setting up your environment and installing ROCm-DS components.
+This topic provides brief guidance and recommendations on setting up your environment and installing AMD Data Science components.
 
 System requirements
 ===================
 
-The following are the ROCm-DS release compatibilities and system requirements: 
+The following are the AMD Data Science release compatibilities and system requirements: 
 
 * `ROCm 7.2.3 <https://rocm.docs.amd.com/projects/install-on-linux/en/docs-7.2.3/>`__
 * Operating Systems: Ubuntu 24.04 and 22.04  
@@ -28,7 +28,7 @@ The following are the ROCm-DS release compatibilities and system requirements:
 Installation instructions
 =========================
 
-Each ROCm-DS 26.03 component must be separately installed as needed. The installation instructions for each component can be found as follows: 
+Each AMD Data Science 26.03 component must be separately installed as needed. The installation instructions for each component can be found as follows: 
 
 * `hipDF Installation instructions <https://rocm.docs.amd.com/projects/hipDF/en/docs-26.03/install/INSTALL.html>`__
 * `hipMM Installation instructions <https://rocm.docs.amd.com/projects/hipMM/en/docs-26.03/install/INSTALL.html>`__

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -32,9 +32,9 @@ subtrees:
   - url: https://instinct.docs.amd.com/latest/
     title: Instinct docs
   - url: https://instinct.docs.amd.com/latest/data-science/ROCmDS-Blogs.html
-    title: ROCm-DS blogs
+    title: Data Science blogs
   - file: contribute/contributing.rst
-    title: Contributing to ROCm-DS
+    title: Contributing to AMD Data Science
 
 - caption: About
   entries:

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,2 +1,2 @@
-rocm-docs-core==1.31.2
+rocm-docs-core==1.38.0
 sphinx-reredirects

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -8,40 +8,40 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   jupyter-cache
     #   referencing
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
     # via pydata-sphinx-theme
 breathe==4.36.0
     # via rocm-docs-core
-certifi==2026.1.4
+certifi==2026.7.22
     # via requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.4.9
     # via requests
-click==8.3.1
+click==8.4.2
     # via
     #   jupyter-cache
     #   sphinx-external-toc
 comm==0.2.3
     # via ipykernel
-cryptography==46.0.3
+cryptography==49.0.0
     # via pyjwt
-debugpy==1.8.19
+debugpy==1.8.21
     # via ipykernel
-decorator==5.2.1
+decorator==5.3.1
     # via ipython
 docutils==0.21.2
     # via
@@ -52,31 +52,31 @@ exceptiongroup==1.3.1
     # via ipython
 executing==2.2.1
     # via stack-data
-fastjsonschema==2.21.2
+fastjsonschema==2.22.1
     # via
     #   nbformat
     #   rocm-docs-core
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.46
+gitpython==3.1.57
     # via rocm-docs-core
-greenlet==3.3.0
+greenlet==3.5.4
     # via sqlalchemy
-idna==3.11
+idna==3.18
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via
     #   jupyter-cache
     #   myst-nb
-ipykernel==7.1.0
+ipykernel==7.3.0
     # via myst-nb
-ipython==8.38.0
+ipython==8.39.0
     # via
     #   ipykernel
     #   myst-nb
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
 jinja2==3.1.6
     # via
@@ -88,7 +88,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-cache==1.0.1
     # via myst-nb
-jupyter-client==8.8.0
+jupyter-client==8.9.1
     # via
     #   ipykernel
     #   nbclient
@@ -104,19 +104,19 @@ markdown-it-py==3.0.0
     #   myst-parser
 markupsafe==3.0.3
     # via jinja2
-matplotlib-inline==0.2.1
+matplotlib-inline==0.2.2
     # via
     #   ipykernel
     #   ipython
-mdit-py-plugins==0.5.0
+mdit-py-plugins==0.6.1
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-nb==1.3.0
+myst-nb==1.4.0
     # via rocm-docs-core
 myst-parser==4.0.1
     # via myst-nb
-nbclient==0.10.4
+nbclient==0.11.0
     # via
     #   jupyter-cache
     #   myst-nb
@@ -125,42 +125,42 @@ nbformat==5.10.4
     #   jupyter-cache
     #   myst-nb
     #   nbclient
-nest-asyncio==1.6.0
+nest-asyncio2==1.7.2
     # via ipykernel
-packaging==25.0
+packaging==26.2
     # via
     #   ipykernel
     #   pydata-sphinx-theme
     #   sphinx
-parso==0.8.5
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
-platformdirs==4.5.1
+platformdirs==4.11.0
     # via jupyter-core
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
-psutil==7.2.1
+psutil==7.2.2
     # via ipykernel
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
-pygithub==2.8.1
+pygithub==2.9.1
     # via rocm-docs-core
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   ipython
     #   pydata-sphinx-theme
     #   sphinx
-pyjwt[crypto]==2.10.1
+pyjwt[crypto]==2.13.0
     # via pygithub
 pynacl==1.6.2
     # via pygithub
@@ -181,7 +181,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.34.2
     # via
     #   pygithub
     #   sphinx
@@ -193,11 +193,11 @@ rpds-py==0.30.0
     #   referencing
 six==1.17.0
     # via python-dateutil
-smmap==5.0.2
+smmap==5.0.3
     # via gitdb
-snowballstemmer==3.0.1
+snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8.1
+soupsieve==2.9.1
     # via beautifulsoup4
 sphinx==8.1.3
     # via
@@ -210,6 +210,7 @@ sphinx==8.1.3
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-multitoc-numbering
     #   sphinx-notfound-page
     #   sphinx-reredirects
 sphinx-book-theme==1.1.4
@@ -218,8 +219,10 @@ sphinx-copybutton==0.5.2
     # via rocm-docs-core
 sphinx-design==0.6.1
     # via rocm-docs-core
-sphinx-external-toc==1.0.1
+sphinx-external-toc==1.1.0
     # via rocm-docs-core
+sphinx-multitoc-numbering==0.1.3
+    # via sphinx-external-toc
 sphinx-notfound-page==1.1.0
     # via rocm-docs-core
 sphinx-reredirects==0.1.6
@@ -236,19 +239,19 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.45
+sqlalchemy==2.0.51
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
-tabulate==0.9.0
+tabulate==0.10.0
     # via jupyter-cache
-tomli==2.4.0
+tomli==2.4.1
     # via sphinx
-tornado==6.5.4
+tornado==6.5.7
     # via
     #   ipykernel
     #   jupyter-client
-traitlets==5.14.3
+traitlets==5.15.1
     # via
     #   ipykernel
     #   ipython
@@ -257,22 +260,24 @@ traitlets==5.14.3
     #   matplotlib-inline
     #   nbclient
     #   nbformat
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   beautifulsoup4
     #   cryptography
     #   exceptiongroup
     #   ipython
+    #   jupyter-client
     #   myst-nb
     #   pydata-sphinx-theme
     #   pygithub
+    #   pyjwt
     #   referencing
     #   sqlalchemy
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   pygithub
     #   requests
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via prompt-toolkit
-zipp==3.23.0
+zipp==4.1.0
     # via importlib-metadata

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -185,7 +185,7 @@ requests==2.32.5
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.31.2
+rocm-docs-core==1.38.0
     # via -r requirements.in
 rpds-py==0.30.0
     # via


### PR DESCRIPTION
Replace ROCm-DS and AMD ROCm Data Science with AMD Data Science for AMD Ecosystem migration.